### PR TITLE
Various fixes

### DIFF
--- a/Assets/HumanWorker/Materials/Body_SSS.material
+++ b/Assets/HumanWorker/Materials/Body_SSS.material
@@ -1,45 +1,24 @@
 {
-    "materialType": "@projectroot@/Cache/Intermediate Assets/materials/types/skin_generated.materialtype",
-    "materialTypeVersion": 4,
+    "materialType": "@projectroot@/Cache/Intermediate Assets/materials/types/standardpbr_generated.materialtype",
+    "materialTypeVersion": 5,
     "propertyValues": {
-        "baseColor.textureBlendMode": "Lerp",
-        "baseColor.textureMap": "../Textures/Body_base_color.png",
-        "detailLayerGroup.blendDetailMask": "../Textures/Body_base_color.png",
-        "detailLayerGroup.enableBaseColor": true,
-        "detailLayerGroup.enableNormals": true,
-        "normal.factor": 0.30000001192092896,
-        "normal.flipX": true,
-        "normal.textureMap": "../Textures/Body_normal.png",
-        "occlusion.diffuseFactor": 0.6600000262260437,
-        "occlusion.diffuseTextureMap": "../Textures/Body_ao.png",
-        "occlusion.diffuseTextureMapUv": "Unwrapped",
-        "roughness.lowerBound": 0.6000000238418579,
-        "roughness.textureMap": "../Textures/Body_roughness.png",
-        "roughness.upperBound": 0.10000000149011612,
-        "specularF0.factor": 0.09000000357627869,
-        "subsurfaceScattering.enableSubsurfaceScattering": true,
-        "subsurfaceScattering.influenceMap": "../Textures/Body_transmission.png",
-        "subsurfaceScattering.quality": 0.3199999928474426,
-        "subsurfaceScattering.scatterColor": [
-            1.0,
-            0.23453116416931152,
-            0.04872205853462219,
+        "baseColor.color": [
+            0.800000011920929,
+            0.800000011920929,
+            0.800000011920929,
             1.0
         ],
-        "subsurfaceScattering.scatterDistance": 1.0,
-        "subsurfaceScattering.subsurfaceScatterFactor": 0.44999998807907104,
-        "subsurfaceScattering.thickness": 0.03999999910593033,
-        "subsurfaceScattering.thicknessMap": "../Textures/Body_sss.png",
-        "subsurfaceScattering.transmissionAttenuation": 0.800000011920929,
-        "subsurfaceScattering.transmissionDistortion": 0.009999999776482582,
-        "subsurfaceScattering.transmissionMode": "ThickObject",
-        "subsurfaceScattering.transmissionPower": 1.7999999523162842,
-        "subsurfaceScattering.transmissionScale": 0.20000000298023224,
-        "subsurfaceScattering.transmissionTint": [
-            0.7968719005584717,
-            0.4905775487422943,
-            0.2383764386177063,
+        "baseColor.textureMap": "../Textures/Body_base_color.png",
+        "emissive.color": [
+            0.0,
+            0.0,
+            0.0,
             1.0
-        ]
+        ],
+        "normal.textureMap": "../Textures/Body_normal.png",
+        "opacity.factor": 1.0,
+        "roughness.factor": 0.827063798904419,
+        "roughness.textureMap": "../Textures/Body_roughness.png",
+        "specularF0.textureMap": "../Textures/Body_sss.png"
     }
 }

--- a/Code/Source/HumanWorker/NpcNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcNavigatorComponent.h
@@ -42,9 +42,10 @@ namespace ROS2::HumanWorker
         ~NpcNavigatorComponent() override = default;
 
         static void Reflect(AZ::ReflectContext* context);
-        // clang-format off
-        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required) {}
-        // clang-format on
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+        {
+            required.push_back(AZ_CRC_CE("ROS2Frame"));
+        }
 
         // AZ::Component overrides
         void Activate() override;
@@ -70,12 +71,7 @@ namespace ROS2::HumanWorker
             AZ::Vector3 m_direction{};
         };
 
-        static constexpr float AcceptableDistanceError = 0.5f;
-        static constexpr float AcceptableAngleError = 0.1f;
-        // clang-format off
-        static bool IsClose(AZ::Vector3 vector1, AZ::Vector3 vector2) { return vector1.GetDistance(vector2) < AcceptableDistanceError; }
-        // clang-format on
-
+        static bool IsClose(AZ::Vector3 vector1, AZ::Vector3 vector2, float acceptableDistanceError);
         static AZ::Transform GetEntityTransform(AZ::EntityId entityId);
         // Assumes that the argument vectors lie in the XY plane.
         static float GetSignedAngleBetweenUnitVectors(AZ::Vector3 unitVector1, AZ::Vector3 unitVector2);
@@ -123,6 +119,8 @@ namespace ROS2::HumanWorker
         float m_linearSpeed{ 1.5f };
         float m_angularSpeed{ 1.0f };
         float m_crossTrackFactor{ 0.1f };
+        float m_acceptableDistanceError{ 0.5f };
+        float m_acceptableAngleError{ 0.1f };
 
         AZStd::vector<AZ::EntityId> m_waypointEntities;
         AZStd::vector<GoalPose> m_goalPath;

--- a/Code/Source/HumanWorker/WaypointSelectorComponent.cpp
+++ b/Code/Source/HumanWorker/WaypointSelectorComponent.cpp
@@ -81,7 +81,7 @@ namespace ROS2::HumanWorker
             AZ_Printf(__func__, "No waypoint entities to select from.") return {};
         }
 
-        std::uniform_int_distribution<size_t> uniformDistribution(0, m_waypoints.size());
+        std::uniform_int_distribution<size_t> uniformDistribution(0, m_waypoints.size() - 1);
         AZStd::vector<AZ::EntityId> waypointPath;
         while (waypointPath.size() != m_waypoints.size())
         {


### PR DESCRIPTION
This pr
fixes:
- Npc Navigator component UB for entities without a ros2 frame.
- Orchestrator using invalid waypoint indices.
- invalid arrival criterion for npcs on a different z plane than the waypoint.
adds:
- Way to configure acceptable angle and distance difference.