### PR TITLE
Npc navigation with poses

### DIFF
--- a/Assets/HumanWorker/HumanWorkerRobot.prefab
+++ b/Assets/HumanWorker/HumanWorkerRobot.prefab
@@ -214,10 +214,21 @@
                     "m_template": {
                         "$type": "NpcWaypointNavigatorComponent",
                         "Detour Navigation Entity": "",
+                        "Cross Track Factor": 0.20000000298023224,
                         "Waypoints": [
                             "",
                             ""
                         ]
+                    }
+                },
+                "ROS2FrameEditorComponent": {
+                    "$type": "ROS2FrameEditorComponent",
+                    "Id": 18218766782150271155,
+                    "ROS2FrameConfiguration": {
+                        "Namespace Configuration": {
+                            "Namespace Strategy": 2,
+                            "Namespace": "HumanWorker"
+                        }
                     }
                 },
                 "ROS2RobotControlComponent": {
@@ -234,23 +245,13 @@
                     "$type": "GenericComponentWrapper",
                     "Id": 3585149160592881723,
                     "m_template": {
-                        "$type": "RigidBodyTwistControlComponent",
-                        "DisableLinearVelocityZOverriding": true
+                        "$type": "RigidBodyTwistControlComponent"
                     }
                 },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 2507038620276963239,
                     "Parent Entity": "ContainerEntity"
-                },
-                "ROS2FrameEditorComponent": {
-                    "$type": "ROS2FrameEditorComponent",
-                    "Id": 18218766782150271155,
-                    "ROS2FrameConfiguration": {
-                        "Namespace Configuration": {
-                            "Namespace Strategy": 2
-                        }
-                    }
                 }
             }
         }

--- a/Assets/HumanWorker/HumanWorkerRobot.prefab
+++ b/Assets/HumanWorker/HumanWorkerRobot.prefab
@@ -81,7 +81,7 @@
                             "TranslationOffset": [
                                 0.0,
                                 0.0,
-                                0.5
+                                1.0
                             ]
                         }
                     }
@@ -151,15 +151,13 @@
                     "Id": 18206091562556464943,
                     "Configuration": {
                         "entityId": "",
-                        "Gravity Enabled": false,
-                        "Lock Linear Z": true,
                         "Lock Angular X": true,
                         "Lock Angular Y": true,
                         "Mass": 359.9741516113281,
                         "Centre of mass offset": [
                             0.0,
                             0.0,
-                            0.5
+                            1.0
                         ],
                         "Inertia tensor": [
                             107.48095703125,
@@ -178,13 +176,10 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 1657780093315026513,
                     "ColliderConfiguration": {
-                        "CollisionGroupId": {
-                            "GroupId": "{E68FAA37-AE19-4093-939A-A4B92759B4F6}"
-                        },
                         "Position": [
                             0.0,
                             0.0,
-                            0.5
+                            1.0
                         ],
                         "MaterialSlots": {
                             "Slots": [
@@ -192,10 +187,10 @@
                                     "Name": "Entire object",
                                     "MaterialAsset": {
                                         "assetId": {
-                                            "guid": "{B33C0402-063E-54B0-A6E6-0C3E3281C183}",
+                                            "guid": "{A7B4CB58-2B38-53A2-B901-AC92B41C1D43}",
                                             "subId": 1
                                         },
-                                        "assetHint": "collisions/collidermaterial.physicsmaterial"
+                                        "assetHint": "humanworker/collisions/collidermaterial.physicsmaterial"
                                     }
                                 }
                             ]
@@ -213,16 +208,16 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 8963879223403550331
                 },
-                "NpcNavigatorComponent": {
+                "NpcWaypointNavigatorComponent": {
                     "$type": "GenericComponentWrapper",
-                    "Id": 8214888317295398113,
+                    "Id": 3409862240064073382,
                     "m_template": {
-                        "$type": "NpcNavigatorComponent",
+                        "$type": "NpcWaypointNavigatorComponent",
                         "Detour Navigation Entity": "",
-                        "Topic Configuration": {
-                            "Topic": "cmd_vel"
-                        },
-                        "Angular Speed": 2.0
+                        "Waypoints": [
+                            "",
+                            ""
+                        ]
                     }
                 },
                 "ROS2RobotControlComponent": {
@@ -239,7 +234,8 @@
                     "$type": "GenericComponentWrapper",
                     "Id": 3585149160592881723,
                     "m_template": {
-                        "$type": "RigidBodyTwistControlComponent"
+                        "$type": "RigidBodyTwistControlComponent",
+                        "DisableLinearVelocityZOverriding": true
                     }
                 },
                 "TransformComponent": {

--- a/Assets/HumanWorker/HumanWorkerRobot.prefab
+++ b/Assets/HumanWorker/HumanWorkerRobot.prefab
@@ -214,6 +214,7 @@
                     "m_template": {
                         "$type": "NpcWaypointNavigatorComponent",
                         "Detour Navigation Entity": "",
+                        "Angular Speed": 1.5,
                         "Cross Track Factor": 0.20000000298023224,
                         "Waypoints": [
                             "",

--- a/Assets/HumanWorker/NavigationExample.prefab
+++ b/Assets/HumanWorker/NavigationExample.prefab
@@ -54,18 +54,6 @@
             "Id": "Entity_[9862683918956]",
             "Name": "EndPoint2",
             "Components": {
-                "EditorDebugDrawTextComponent": {
-                    "$type": "EditorDebugDrawTextComponent",
-                    "Id": 7276000702152342883,
-                    "Element": {
-                        "Text": "EndPoint2",
-                        "DrawMode": 1,
-                        "TargetEntity": ""
-                    },
-                    "Settings": {
-                        "VisibleInGame": false
-                    }
-                },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 15851377247950876879
@@ -128,18 +116,6 @@
             "Id": "Entity_[9871273853548]",
             "Name": "EndPoint1",
             "Components": {
-                "EditorDebugDrawTextComponent": {
-                    "$type": "EditorDebugDrawTextComponent",
-                    "Id": 12282642636597983427,
-                    "Element": {
-                        "Text": "EndPoint1",
-                        "DrawMode": 1,
-                        "TargetEntity": ""
-                    },
-                    "Settings": {
-                        "VisibleInGame": false
-                    }
-                },
                 "EditorDisabledCompositionComponent": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 15851377247950876879
@@ -437,8 +413,7 @@
                             "Agent Radius": 0.4000000059604645,
                             "Detail Sample Distance": 1.0,
                             "Detail Sample Max Error": 0.10000000149011612,
-                            "Edge Max Error": 0.75,
-                            "Editor Preview": true
+                            "Edge Max Error": 0.75
                         }
                     }
                 },
@@ -545,19 +520,19 @@
                     "value": 0.0
                 },
                 {
-                    "op": "add",
-                    "path": "/Entities/Entity_[66011467218485]/Components/NpcNavigatorComponent/m_template/Waypoints/0",
-                    "value": "../Entity_[9871273853548]"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[66011467218485]/Components/NpcNavigatorComponent/m_template/Waypoints/1",
-                    "value": "../Entity_[9862683918956]"
+                    "op": "replace",
+                    "path": "/Entities/Entity_[66011467218485]/Components/NpcWaypointNavigatorComponent/m_template/Detour Navigation Entity",
+                    "value": "../Entity_[9879863788140]"
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[66011467218485]/Components/NpcNavigatorComponent/m_template/Detour Navigation Entity",
-                    "value": "../Entity_[9879863788140]"
+                    "path": "/Entities/Entity_[66011467218485]/Components/NpcWaypointNavigatorComponent/m_template/Waypoints/0",
+                    "value": "../Entity_[9871273853548]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[66011467218485]/Components/NpcWaypointNavigatorComponent/m_template/Waypoints/1",
+                    "value": "../Entity_[9862683918956]"
                 }
             ]
         }

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -59,6 +59,9 @@ ly_add_target(
         Gem::EMotionFX.Static
 )
 
+target_depends_on_ros2_packages(${gem_name}.Private.Object geometry_msgs)
+target_depends_on_ros2_packages(${gem_name}.Private.Object tf2)
+
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(
     NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}

--- a/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.cpp
+++ b/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.cpp
@@ -82,13 +82,15 @@ namespace ROS2::HumanWorker
             else
             {
                 m_delayedTickUpdateActive = false;
+                m_initialUpdate = false;
                 UpdateNavigationMesh();
             }
         }
-        else
+        else if (m_initialUpdate)
         {
             // Update the navigation mesh on the first tick if it is not delayed.
             // The navigation mesh requires a manual update and the mesh is not created automatically on the start of the simulation.
+            m_initialUpdate = false;
             UpdateNavigationMesh();
         }
 

--- a/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.cpp
+++ b/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.cpp
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include "AzCore/Serialization/EditContextConstants.inl"
 #include <HumanWorker/NavigationMeshOrchestratorComponent.h>
 
 #include <AzCore/Serialization/EditContext.h>
@@ -61,14 +60,17 @@ namespace ROS2::HumanWorker
 
     void NavigationMeshOrchestratorComponent::OnTick(float deltaTime, AZ::ScriptTimePoint time)
     {
-        if (m_delayedTickUpdateActive && m_delayedTickUpdate > 0)
+        if (m_delayedTickUpdateActive)
         {
-            m_delayedTickUpdate--;
-        }
-        else if (m_delayedTickUpdateActive && m_delayedTickUpdate == 0)
-        {
-            m_delayedTickUpdateActive = false;
-            UpdateNavigationMesh();
+            if (m_delayedTickUpdate > 0)
+            {
+                m_delayedTickUpdate--;
+            }
+            else
+            {
+                m_delayedTickUpdateActive = false;
+                UpdateNavigationMesh();
+            }
         }
 
         if (m_initialUpdate)

--- a/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.cpp
+++ b/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.cpp
@@ -27,28 +27,41 @@ namespace ROS2::HumanWorker
 
             if (AZ::EditContext* editContext = serialize->GetEditContext())
             {
-                editContext
-                    ->Class<NavigationMeshOrchestratorComponent>("Navigation Orchestrator", "")
+                editContext->Class<NavigationMeshOrchestratorComponent>("Navigation Orchestrator", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &NavigationMeshOrchestratorComponent::m_shouldUpdate, "Should the mesh be updated", "")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &NavigationMeshOrchestratorComponent::m_updateFrequency, "NavMesh Update Frequency", "")
-                        ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                        ->Attribute(AZ::Edit::Attributes::Visibility, &NavigationMeshOrchestratorComponent::m_shouldUpdate)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &NavigationMeshOrchestratorComponent::m_delayedTickUpdateActive, "Use Delayed Update", "")
+                        AZ::Edit::UIHandlers::Default,
+                        &NavigationMeshOrchestratorComponent::m_shouldUpdate,
+                        "Should the mesh be updated",
+                        "")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &NavigationMeshOrchestratorComponent::m_delayedTickUpdate, "Ticks to update after", "")
-                        ->Attribute(AZ::Edit::Attributes::Visibility, &NavigationMeshOrchestratorComponent::m_delayedTickUpdateActive);
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &NavigationMeshOrchestratorComponent::m_updateFrequency,
+                        "NavMesh Update Frequency",
+                        "")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &NavigationMeshOrchestratorComponent::m_shouldUpdate)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &NavigationMeshOrchestratorComponent::m_delayedTickUpdateActive,
+                        "Use Delayed Update",
+                        "")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &NavigationMeshOrchestratorComponent::m_delayedTickUpdate,
+                        "Ticks to update after",
+                        "")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &NavigationMeshOrchestratorComponent::m_delayedTickUpdateActive);
             }
         }
     }
 
     void NavigationMeshOrchestratorComponent::Activate()
     {
-        m_initialUpdate = true;
         AZ::EntityBus::Handler::BusConnect(GetEntityId());
     }
 
@@ -72,12 +85,13 @@ namespace ROS2::HumanWorker
                 UpdateNavigationMesh();
             }
         }
-
-        if (m_initialUpdate)
+        else
         {
+            // Update the navigation mesh on the first tick if it is not delayed.
+            // The navigation mesh requires a manual update and the mesh is not created automatically on the start of the simulation.
             UpdateNavigationMesh();
-            m_initialUpdate = false;
         }
+
         if (m_shouldUpdate && (m_elapsedTime += deltaTime) * m_updateFrequency > 1.0f)
         {
             m_elapsedTime = 0.0f;

--- a/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.h
+++ b/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.h
@@ -50,7 +50,6 @@ namespace ROS2::HumanWorker
         bool m_shouldUpdate{ false };
         float m_updateFrequency{ 0.1f }; //!< In Hertz.
         float m_elapsedTime{ 0.0f }; //!< In seconds.
-        bool m_initialUpdate{ false };
         int m_delayedTickUpdate{ 0 };
         bool m_delayedTickUpdateActive{ false };
     };

--- a/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.h
+++ b/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.h
@@ -51,5 +51,7 @@ namespace ROS2::HumanWorker
         float m_updateFrequency{ 0.1f }; //!< In Hertz.
         float m_elapsedTime{ 0.0f }; //!< In seconds.
         bool m_initialUpdate{ false };
+        int m_delayedTickUpdate{ 0 };
+        bool m_delayedTickUpdateActive{ false };
     };
 } // namespace ROS2::HumanWorker

--- a/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.h
+++ b/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.h
@@ -50,6 +50,7 @@ namespace ROS2::HumanWorker
         bool m_shouldUpdate{ false };
         float m_updateFrequency{ 0.1f }; //!< In Hertz.
         float m_elapsedTime{ 0.0f }; //!< In seconds.
+        bool m_initialUpdate{ true };
         int m_delayedTickUpdate{ 0 };
         bool m_delayedTickUpdateActive{ false };
     };

--- a/Code/Source/HumanWorker/NpcNavigatorComponent.cpp
+++ b/Code/Source/HumanWorker/NpcNavigatorComponent.cpp
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include "AzCore/RTTI/ReflectContext.h"
-#include "AzCore/Serialization/EditContextConstants.inl"
 #include <HumanWorker/NpcNavigatorComponent.h>
 
 #include <AzCore/Component/Component.h>
@@ -16,6 +14,7 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/EBus/Results.h>
 #include <AzCore/Math/Vector3.h>
+#include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <HumanWorker/WaypointBus.h>

--- a/Code/Source/HumanWorker/NpcNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcNavigatorComponent.h
@@ -86,7 +86,7 @@ namespace ROS2::HumanWorker
         }
 
         // Path calculations and navigation
-        static Speed CalculateSpeedForGoal(
+        Speed CalculateSpeedForGoal(
             const AZ::Transform& currentTransform,
             const GoalPose& goal,
             const AZ::Vector3& startPosition,
@@ -140,6 +140,8 @@ namespace ROS2::HumanWorker
         bool m_debugMode{ false };
 
         bool m_useTagsForNavigationMesh{ false };
+
+        bool m_preventWalkingInCircle{ false };
 
         // ROS2 communication variables
         TopicConfiguration m_twistTopicConfiguration;

--- a/Code/Source/HumanWorker/NpcNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcNavigatorComponent.h
@@ -109,6 +109,8 @@ namespace ROS2::HumanWorker
         // EntityDebugDisplayEventBus overrides
         void DisplayEntityViewport(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay) override;
 
+        bool UseExplicitlyDefinedNavigationMesh() const;
+
         NavigationState m_state{ NavigationState::Navigate };
         AZ::EntityId m_navigationEntity;
 
@@ -124,6 +126,8 @@ namespace ROS2::HumanWorker
         float m_acceptableDistanceError{ 0.5f };
         float m_acceptableAngleError{ 0.1f };
         bool m_debugMode{ false };
+
+        bool m_useTagsForNavigationMesh{ false };
 
         // ROS2 communication variables
         TopicConfiguration m_twistTopicConfiguration;

--- a/Code/Source/HumanWorker/NpcNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcNavigatorComponent.h
@@ -92,7 +92,7 @@ namespace ROS2::HumanWorker
         static NpcNavigatorComponent::Speed CalculateSpeedForGoal(
             const AZ::Transform& currentTransform, GoalPose goal, AZ::Vector3 startPosition, Speed maxSpeed, float crossTrackFactor);
         [[nodiscard]] AZStd::vector<NpcNavigatorComponent::GoalPose> ConstructGoalPath(
-            const AZStd::vector<AZ::Vector3>& positionPath, const AZ::Quaternion waypointOrientation) const;
+            const AZStd::vector<AZ::Vector3>& positionPath, const AZ::Quaternion& waypointOrientation) const;
         AZStd::vector<AZ::Vector3> FindPathBetweenPositions(AZ::Vector3 currentPosition, AZ::Vector3 goalPosition);
 
         // Virtual functions to be implemented by derived classes with different waypoint definitions

--- a/Code/Source/HumanWorker/NpcPoseNavigatorComponent.cpp
+++ b/Code/Source/HumanWorker/NpcPoseNavigatorComponent.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root
+ * of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <HumanWorker/NpcPoseNavigatorComponent.h>
+
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Math/Quaternion.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/parallel/lock.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/ROS2GemUtilities.h>
+#include <ROS2/Utilities/ROS2Conversions.h>
+#include <ROS2/Utilities/ROS2Names.h>
+
+namespace ROS2::HumanWorker
+{
+    NpcPoseNavigatorComponent::NpcPoseNavigatorComponent()
+        : NpcNavigatorComponent()
+    {
+        m_poseTopicConfiguration.m_topic = "goal_pose";
+        m_poseTopicConfiguration.m_type = "geometry_msgs::msg::PoseStamped";
+    }
+
+    void NpcPoseNavigatorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<NpcPoseNavigatorComponent, NpcNavigatorComponent>()->Version(1)->Field(
+                "Pose Topic Configuration", &NpcPoseNavigatorComponent::m_poseTopicConfiguration);
+
+            if (AZ::EditContext* editContext = serialize->GetEditContext())
+            {
+                editContext
+                    ->Class<NpcPoseNavigatorComponent>(
+                        "Npc Pose Navigator",
+                        "Component used for navigating an npc along poses sent with ROS2."
+                        "It processes paths and publishes twist messages")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "HumanWorker")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &NpcPoseNavigatorComponent::m_poseTopicConfiguration, "Topic Configuration", "")
+                    ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "Pose waypoints topic");
+            }
+        }
+    }
+
+    void NpcPoseNavigatorComponent::Activate()
+    {
+        auto ros2Node = ROS2::ROS2Interface::Get()->GetNode();
+        const auto* ros2_frame_component = m_entity->FindComponent<ROS2::ROS2FrameComponent>();
+        auto namespaced_topic_name =
+            ROS2::ROS2Names::GetNamespacedName(ros2_frame_component->GetNamespace(), m_poseTopicConfiguration.m_topic);
+        m_poseSubscription = ros2Node->create_subscription<geometry_msgs::msg::PoseStamped>(
+            namespaced_topic_name.data(),
+            m_poseTopicConfiguration.GetQoS(),
+            [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg)
+            {
+                AZStd::lock_guard<AZStd::mutex> lock(m_goalPoseQueueMutex);
+                const AZ::Transform transform = ROS2::ROS2Conversions::FromROS2Pose(msg->pose);
+
+                m_goalPoseQueue.push({ transform.GetTranslation(), transform.GetRotation().GetEulerRadians() });
+            });
+
+        NpcNavigatorComponent::Activate();
+    }
+
+    void NpcPoseNavigatorComponent::Deactivate()
+    {
+        NpcNavigatorComponent::Deactivate();
+
+        m_poseSubscription.reset();
+    }
+    AZStd::vector<NpcNavigatorComponent::GoalPose> NpcPoseNavigatorComponent::TryFindGoalPath()
+    {
+        if (m_goalPoseQueue.empty())
+        {
+            return {};
+        }
+
+        GoalPose goalPose;
+        {
+            AZStd::lock_guard<AZStd::mutex> lock(m_goalPoseQueueMutex);
+            goalPose = m_goalPoseQueue.front();
+        }
+        const AZStd::vector<AZ::Vector3> positionPath =
+            FindPathBetweenPositions(GetCurrentTransform().GetTranslation(), goalPose.m_position);
+
+        m_startPosition = GetCurrentTransform().GetTranslation();
+
+        if (positionPath.empty())
+        {
+            AZStd::lock_guard<AZStd::mutex> lock(m_goalPoseQueueMutex);
+            m_goalPoseQueue.pop();
+
+            return {};
+        }
+
+        return ConstructGoalPath(positionPath, AZ::Quaternion::CreateFromEulerAnglesRadians(goalPose.m_direction));
+    }
+
+    NpcPoseNavigatorComponent::Speed NpcPoseNavigatorComponent::CalculateSpeed(float deltaTime)
+    {
+        switch (m_state)
+        {
+        case NavigationState::Idle:
+            {
+                AZStd::lock_guard<AZStd::mutex> lock(m_goalPoseQueueMutex);
+                m_goalPoseQueue.pop();
+            }
+            m_goalPath.clear();
+            m_goalIndex = 0;
+
+            m_state = NavigationState::Navigate;
+
+            m_startPosition = GetCurrentTransform().GetTranslation();
+
+            return {};
+        case NavigationState::Rotate:
+            {
+                AZ_Assert(
+                    m_goalIndex == m_goalPath.size(), "The Npc Navigator component is in an invalid state due to programmer's error.");
+                const float BearingError = GetSignedAngleBetweenUnitVectors(
+                    GetCurrentTransform().GetRotation().TransformVector(AZ::Vector3::CreateAxisX()),
+                    m_goalPath[m_goalIndex - 1].m_direction);
+
+                if (std::abs(BearingError) < m_acceptableAngleError)
+                {
+                    m_state = NavigationState::Idle;
+
+                    return {};
+                }
+                else
+                {
+                    return {
+                        .m_linear = 0.0f,
+                        .m_angular = m_angularSpeed * BearingError,
+                    };
+                }
+            }
+        case NavigationState::Navigate:
+            if (IsClose(m_goalPath[m_goalIndex].m_position, GetCurrentTransform().GetTranslation(), m_acceptableDistanceError))
+            {
+                if (++m_goalIndex == m_goalPath.size())
+                {
+                    m_state = NavigationState::Rotate;
+
+                    return {};
+                }
+
+                m_startPosition = m_goalPath[m_goalIndex - 1].m_position;
+            }
+
+            return CalculateSpeedForGoal(
+                GetCurrentTransform(),
+                m_goalPath[m_goalIndex],
+                m_startPosition,
+                { .m_linear = m_linearSpeed, .m_angular = m_angularSpeed },
+                m_crossTrackFactor);
+        }
+    }
+
+    void NpcPoseNavigatorComponent::RecalculateCurrentGoalPath()
+    {
+        m_goalIndex = 0;
+        m_goalPath = TryFindGoalPath();
+    }
+} // namespace ROS2::HumanWorker

--- a/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
@@ -13,12 +13,15 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
+#include <AzCore/Time/ITime.h>
 #include <AzCore/std/containers/queue.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <ROS2/Communication/TopicConfiguration.h>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <rclcpp/publisher.hpp>
 #include <rclcpp/subscription.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 namespace ROS2::HumanWorker
 {
@@ -48,5 +51,9 @@ namespace ROS2::HumanWorker
         bool m_useROS2PoseForWaypoint{ false };
         ROS2::TopicConfiguration m_poseTopicConfiguration;
         std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::PoseStamped>> m_poseSubscription = nullptr;
+
+        std::unique_ptr<tf2_ros::Buffer> m_tfBuffer = nullptr;
+        std::unique_ptr<tf2_ros::TransformListener> m_tfListener = nullptr;
+        AZStd::string m_worldFrame;
     };
 } // namespace ROS2::HumanWorker

--- a/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root
+ * of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <HumanWorker/NpcNavigatorComponent.h>
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/std/containers/queue.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <ROS2/Communication/TopicConfiguration.h>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <rclcpp/publisher.hpp>
+#include <rclcpp/subscription.hpp>
+
+namespace ROS2::HumanWorker
+{
+    class NpcPoseNavigatorComponent : public NpcNavigatorComponent
+    {
+    public:
+        AZ_COMPONENT(NpcPoseNavigatorComponent, "{9D90BDCB-5353-485C-93A4-B1FF63862380}", NpcNavigatorComponent);
+
+        NpcPoseNavigatorComponent();
+        ~NpcPoseNavigatorComponent() override = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        // AZ::Component overrides
+        void Activate() override;
+        void Deactivate() override;
+
+    private:
+        // NpcNavigatorComponent overrides
+        AZStd::vector<GoalPose> TryFindGoalPath() override;
+        NpcPoseNavigatorComponent::Speed CalculateSpeed(float deltaTime) override;
+        void RecalculateCurrentGoalPath() override;
+
+        AZStd::queue<GoalPose> m_goalPoseQueue;
+        AZStd::mutex m_goalPoseQueueMutex;
+
+        bool m_useROS2PoseForWaypoint{ false };
+        ROS2::TopicConfiguration m_poseTopicConfiguration;
+        std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::PoseStamped>> m_poseSubscription = nullptr;
+    };
+} // namespace ROS2::HumanWorker

--- a/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
@@ -54,6 +54,5 @@ namespace ROS2::HumanWorker
 
         std::unique_ptr<tf2_ros::Buffer> m_tfBuffer = nullptr;
         std::unique_ptr<tf2_ros::TransformListener> m_tfListener = nullptr;
-        AZStd::string m_worldFrame;
     };
 } // namespace ROS2::HumanWorker

--- a/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
@@ -48,7 +48,7 @@ namespace ROS2::HumanWorker
         AZStd::queue<GoalPose> m_goalPoseQueue;
         AZStd::mutex m_goalPoseQueueMutex;
 
-        bool m_useROS2PoseForWaypoint{ false };
+        bool m_rotateToPoseHeading = true;
         ROS2::TopicConfiguration m_poseTopicConfiguration;
         std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::PoseStamped>> m_poseSubscription = nullptr;
 

--- a/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.cpp
+++ b/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.cpp
@@ -128,7 +128,8 @@ namespace ROS2::HumanWorker
         case NavigationState::Navigate:
             if (IsClose(m_goalPath[m_goalIndex].m_position, GetCurrentTransform().GetTranslation(), m_acceptableDistanceError))
             {
-                if ((m_goalIndex + 1) == m_goalPath.size())
+                m_goalIndex++;
+                if (m_goalIndex == m_goalPath.size())
                 {
                     if (m_waypointConfiguration.m_orientationCaptured)
                     {
@@ -142,8 +143,7 @@ namespace ROS2::HumanWorker
                     }
                     return {};
                 }
-                m_startPosition = m_goalPath[m_goalIndex].m_position;
-                m_goalIndex++;
+                m_startPosition = m_goalPath[m_goalIndex - 1].m_position;
             }
 
             return CalculateSpeedForGoal(

--- a/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.cpp
+++ b/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root
+ * of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <HumanWorker/NpcWaypointNavigatorComponent.h>
+
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <HumanWorker/WaypointBus.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/ROS2GemUtilities.h>
+#include <ROS2/Utilities/ROS2Names.h>
+
+namespace ROS2::HumanWorker
+{
+    void NpcWaypointNavigatorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        NpcNavigatorComponent::Reflect(context);
+
+        if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<NpcWaypointNavigatorComponent, NpcNavigatorComponent>()
+                ->Version(1)
+                ->Field("Restart on traversed", &NpcWaypointNavigatorComponent::m_restartOnTraversed)
+                ->Field("Waypoints", &NpcWaypointNavigatorComponent::m_waypointEntities);
+
+            if (AZ::EditContext* editContext = serialize->GetEditContext())
+            {
+                editContext
+                    ->Class<NpcWaypointNavigatorComponent>(
+                        "Npc Waypoint Navigator",
+                        "Component used for navigating an npc along a selected waypoint path."
+                        "It processes paths and publishes twist messages")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "HumanWorker")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &NpcWaypointNavigatorComponent::m_restartOnTraversed, "Restart on traversed", "")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &NpcWaypointNavigatorComponent::m_waypointEntities, "Waypoints", "");
+            }
+        }
+    }
+
+    void NpcWaypointNavigatorComponent::Activate()
+    {
+        NpcNavigatorComponent::Activate();
+        NpcNavigatorRequestBus::Handler::BusConnect(GetEntityId());
+
+        m_startPosition = GetCurrentTransform().GetTranslation();
+    }
+
+    void NpcWaypointNavigatorComponent::Deactivate()
+    {
+        NpcNavigatorRequestBus::Handler::BusDisconnect();
+        NpcNavigatorComponent::Deactivate();
+    }
+
+    AZStd::vector<NpcNavigatorComponent::GoalPose> NpcWaypointNavigatorComponent::TryFindGoalPath()
+    {
+        if (m_waypointIndex >= m_waypointEntities.size())
+        {
+            return {};
+        }
+
+        const AZ::EntityId WaypointEntity = m_waypointEntities[m_waypointIndex];
+        const AZStd::vector<AZ::Vector3> PositionPath =
+            FindPathBetweenPositions(GetCurrentTransform().GetTranslation(), GetEntityTransform(WaypointEntity).GetTranslation());
+        if (PositionPath.empty())
+        {
+            return {};
+        }
+
+        m_waypointConfiguration = FetchWaypointConfiguration(WaypointEntity);
+        return ConstructGoalPath(PositionPath, GetEntityTransform(WaypointEntity).GetRotation());
+    }
+
+    NpcWaypointNavigatorComponent::Speed NpcWaypointNavigatorComponent::CalculateSpeed(float deltaTime)
+    {
+        switch (m_state)
+        {
+        case NavigationState::Idle:
+            if ((m_waypointConfiguration.m_idleTime -= deltaTime) <= 0.0f)
+            {
+                m_goalIndex = 0;
+                if (++m_waypointIndex >= m_waypointEntities.size() && m_restartOnTraversed)
+                {
+                    m_waypointIndex = 0;
+                }
+                m_goalPath.clear();
+                m_waypointConfiguration = FetchWaypointConfiguration(m_waypointEntities[m_waypointIndex]);
+                m_state = NavigationState::Navigate;
+
+                m_startPosition = GetCurrentTransform().GetTranslation();
+            }
+            return {};
+        case NavigationState::Rotate:
+            {
+                AZ_Assert(
+                    m_goalIndex == m_goalPath.size(), "The Npc Navigator component is in an invalid state due to programmer's error.");
+                const float BearingError = GetSignedAngleBetweenUnitVectors(
+                    GetCurrentTransform().GetRotation().TransformVector(AZ::Vector3::CreateAxisX()),
+                    m_goalPath[m_goalIndex - 1].m_direction);
+
+                if (std::abs(BearingError) < m_acceptableAngleError)
+                {
+                    m_state = NavigationState::Idle;
+                    NpcNavigatorNotificationBus::Event(
+                        GetEntityId(), &HumanWorker::NpcNavigatorNotifications::OnWaypointReached, m_waypointConfiguration);
+                    return {};
+                }
+                else
+                {
+                    return {
+                        .m_linear = 0.0f,
+                        .m_angular = m_angularSpeed * BearingError,
+                    };
+                }
+            }
+        case NavigationState::Navigate:
+            if (IsClose(m_goalPath[m_goalIndex].m_position, GetCurrentTransform().GetTranslation(), m_acceptableDistanceError))
+            {
+                if (++m_goalIndex == m_goalPath.size())
+                {
+                    if (m_waypointConfiguration.m_orientationCaptured)
+                    {
+                        m_state = NavigationState::Rotate;
+                    }
+                    else
+                    {
+                        m_state = NavigationState::Idle;
+                        NpcNavigatorNotificationBus::Event(
+                            GetEntityId(), &HumanWorker::NpcNavigatorNotifications::OnWaypointReached, m_waypointConfiguration);
+                    }
+                    return {};
+                }
+                m_startPosition = m_goalPath[m_goalIndex - 1].m_position;
+            }
+
+            return CalculateSpeedForGoal(
+                GetCurrentTransform(),
+                m_goalPath[m_goalIndex],
+                m_startPosition,
+                { .m_linear = m_linearSpeed, .m_angular = m_angularSpeed },
+                m_crossTrackFactor);
+        }
+    }
+
+    void NpcWaypointNavigatorComponent::RecalculateCurrentGoalPath()
+    {
+        if (m_waypointIndex == m_waypointEntities.size())
+        {
+            return;
+        }
+
+        m_goalIndex = 0;
+        m_goalPath = TryFindGoalPath();
+    }
+
+    WaypointConfiguration NpcWaypointNavigatorComponent::FetchWaypointConfiguration(AZ::EntityId waypointEntityId)
+    {
+        WaypointConfiguration waypointConfiguration;
+        WaypointRequestBus::EventResult(waypointConfiguration, waypointEntityId, &WaypointRequests::GetConfiguration);
+        return waypointConfiguration;
+    }
+
+    void NpcWaypointNavigatorComponent::SelectWaypointPath(const AZStd::vector<AZ::EntityId>& waypointEntityIds)
+    {
+        m_goalIndex = 0;
+        m_goalPath.clear();
+        m_state = NavigationState::Navigate;
+        m_waypointIndex = 0;
+        m_waypointEntities.clear();
+        m_waypointEntities = waypointEntityIds;
+    }
+
+} // namespace ROS2::HumanWorker

--- a/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root
+ * of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <HumanWorker/NpcNavigatorComponent.h>
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/std/containers/queue.h>
+#include <AzCore/std/containers/vector.h>
+#include <ROS2/Communication/TopicConfiguration.h>
+#include <geometry_msgs/msg/twist.hpp>
+#include <rclcpp/publisher.hpp>
+
+namespace ROS2::HumanWorker
+{
+    class NpcWaypointNavigatorComponent
+        : public NpcNavigatorComponent
+        , private NpcNavigatorRequestBus::Handler
+    {
+    public:
+        AZ_COMPONENT(NpcWaypointNavigatorComponent, "{2B71BDA6-B986-4627-8E68-15821565F503}", AZ::Component);
+
+        NpcWaypointNavigatorComponent() = default;
+        ~NpcWaypointNavigatorComponent() override = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        // AZ::Component overrides
+        void Activate() override;
+        void Deactivate() override;
+
+    private:
+        // NpcNavigatorComponent overrides
+        AZStd::vector<NpcNavigatorComponent::GoalPose> TryFindGoalPath() override;
+        NpcNavigatorComponent::Speed CalculateSpeed(float deltaTime) override;
+        void RecalculateCurrentGoalPath() override;
+
+        // NpcNavigatorRequestBus overrides
+        void SelectWaypointPath(const AZStd::vector<AZ::EntityId>& waypointEntityIds) override;
+
+        static WaypointConfiguration FetchWaypointConfiguration(AZ::EntityId waypointEntityId);
+
+        AZStd::vector<AZ::EntityId> m_waypointEntities;
+        size_t m_waypointIndex{ 0LU };
+        WaypointConfiguration m_waypointConfiguration;
+
+        bool m_restartOnTraversed{ true };
+    };
+} // namespace ROS2::HumanWorker

--- a/Code/Source/HumanWorkerModuleInterface.cpp
+++ b/Code/Source/HumanWorkerModuleInterface.cpp
@@ -6,6 +6,9 @@
  *
  */
 #include "HumanWorkerModuleInterface.h"
+#include "HumanWorker/NpcPoseNavigatorComponent.h"
+#include "HumanWorker/NpcWaypointNavigatorComponent.h"
+
 #include <AzCore/Memory/Memory.h>
 
 #include <HumanWorker/AnimGraphInputProviderComponent.h>
@@ -27,9 +30,10 @@ namespace HumanWorker
             {
                 ROS2::HumanWorker::AnimGraphInputProviderComponent::CreateDescriptor(),
                 ROS2::HumanWorker::NavigationMeshOrchestratorComponent::CreateDescriptor(),
-                ROS2::HumanWorker::NpcNavigatorComponent::CreateDescriptor(),
                 ROS2::HumanWorker::WaypointComponent::CreateDescriptor(),
                 ROS2::HumanWorker::WaypointSelectorComponent::CreateDescriptor(),
+                ROS2::HumanWorker::NpcWaypointNavigatorComponent::CreateDescriptor(),
+                ROS2::HumanWorker::NpcPoseNavigatorComponent::CreateDescriptor(),
             });
     }
 } // namespace HumanWorker

--- a/Code/Source/HumanWorkerModuleInterface.cpp
+++ b/Code/Source/HumanWorkerModuleInterface.cpp
@@ -6,14 +6,14 @@
  *
  */
 #include "HumanWorkerModuleInterface.h"
-#include "HumanWorker/NpcPoseNavigatorComponent.h"
-#include "HumanWorker/NpcWaypointNavigatorComponent.h"
 
 #include <AzCore/Memory/Memory.h>
 
 #include <HumanWorker/AnimGraphInputProviderComponent.h>
 #include <HumanWorker/NavigationMeshOrchestratorComponent.h>
 #include <HumanWorker/NpcNavigatorComponent.h>
+#include <HumanWorker/NpcPoseNavigatorComponent.h>
+#include <HumanWorker/NpcWaypointNavigatorComponent.h>
 #include <HumanWorker/WaypointComponent.h>
 #include <HumanWorker/WaypointSelectorComponent.h>
 

--- a/Code/humanworker_private_files.cmake
+++ b/Code/humanworker_private_files.cmake
@@ -7,6 +7,10 @@ set(FILES
     Source/HumanWorker/AnimGraphInputProviderComponent.h
     Source/HumanWorker/NavigationMeshOrchestratorComponent.cpp
     Source/HumanWorker/NavigationMeshOrchestratorComponent.h
+    Source/HumanWorker/NpcWaypointNavigatorComponent.cpp
+    Source/HumanWorker/NpcWaypointNavigatorComponent.h
+    Source/HumanWorker/NpcPoseNavigatorComponent.cpp
+    Source/HumanWorker/NpcPoseNavigatorComponent.h
     Source/HumanWorker/NpcNavigatorComponent.cpp
     Source/HumanWorker/NpcNavigatorComponent.h
     Source/HumanWorker/WaypointComponent.cpp

--- a/gem.json
+++ b/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "HumanWorker",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "display_name": "HumanWorker",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",


### PR DESCRIPTION
This PR is based on the zpp_version branch. It can be only merged the zpp_version branch.

I've created a component based on the NPC navigation that enables the definition of waypoints using poses. This changes the structure of the NPC navigator. This component has been split into a waypoint and pose navigation components.

I've also added the ability to delay mesh creation in case of not all collision objects are available during startup.

In addition, now each navigator component can be configured with tags. This enables easy spawning of NPCs. A detour component should have a tag with a name (for example NPCNavigation). Each NPC prefab should then have the same tag. On activation, a detour navigation component with the specified tag will be automatically added to the navigation component.