### PR TITLE
Fix build for cmake 3.28.3 as in o3de#17605

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -128,7 +128,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(


### PR DESCRIPTION
There used to be a problem with gem generator which makes gems impossible to build with newer cmake tools. Please see https://github.com/o3de/o3de/pull/17605 for details.