### PR TITLE
Change namespace ROS2::HumanWorker -> HumanWorker

### DIFF
--- a/Code/Include/HumanWorker/NpcNavigatorBus.h
+++ b/Code/Include/HumanWorker/NpcNavigatorBus.h
@@ -13,7 +13,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <HumanWorker/WaypointBus.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     class NpcNavigatorRequests
     {
@@ -26,7 +26,7 @@ namespace ROS2::HumanWorker
         virtual void SelectWaypointPath(const AZStd::vector<AZ::EntityId>& waypointEntityIds) = 0;
 
         //! Select new waypoint et given location to navigate to.
-        virtual void GoToLocation(const AZ::EntityId& location) =0;
+        virtual void GoToLocation(const AZ::EntityId& location) = 0;
     };
 
     class NpcNavigatorRequestBusTraits : public AZ::EBusTraits
@@ -38,13 +38,11 @@ namespace ROS2::HumanWorker
         static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         using BusIdType = AZ::EntityId;
         //////////////////////////////////////////////////////////////////////////
-
     };
 
     using NpcNavigatorRequestBus = AZ::EBus<NpcNavigatorRequests, NpcNavigatorRequestBusTraits>;
 
-    class NpcNavigatorNotifications
-        : public AZ::EBusTraits
+    class NpcNavigatorNotifications : public AZ::EBusTraits
     {
     public:
         //////////////////////////////////////////////////////////////////////////
@@ -56,8 +54,10 @@ namespace ROS2::HumanWorker
 
         //! Notification that the npc has reached a waypoint.
         //! @param waypointConfig The configuration of the waypoint that was reached.
-        virtual void OnWaypointReached([[maybe_unused]] WaypointConfiguration waypointConfig) {}
+        virtual void OnWaypointReached([[maybe_unused]] WaypointConfiguration waypointConfig)
+        {
+        }
     };
 
     using NpcNavigatorNotificationBus = AZ::EBus<NpcNavigatorNotifications>;
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Include/HumanWorker/WaypointBus.h
+++ b/Code/Include/HumanWorker/WaypointBus.h
@@ -14,7 +14,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <HumanWorker/WaypointConfiguration.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     class WaypointRequests
     {
@@ -37,4 +37,4 @@ namespace ROS2::HumanWorker
     };
 
     using WaypointRequestBus = AZ::EBus<WaypointRequests, WaypointRequestBusTraits>;
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Include/HumanWorker/WaypointConfiguration.h
+++ b/Code/Include/HumanWorker/WaypointConfiguration.h
@@ -8,7 +8,7 @@
  */
 #pragma once
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     struct WaypointConfiguration
     {
@@ -39,4 +39,4 @@ namespace ROS2::HumanWorker
         bool m_orientationCaptured{ false };
         float m_idleTime{ 0 };
     };
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/AnimGraphInputProviderComponent.cpp
+++ b/Code/Source/HumanWorker/AnimGraphInputProviderComponent.cpp
@@ -13,7 +13,7 @@
 #include <LmbrCentral/Shape/SplineComponentBus.h>
 #include <ROS2/ROS2Bus.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     void AnimGraphInputProviderComponent::Reflect(AZ::ReflectContext* context)
     {
@@ -29,7 +29,7 @@ namespace ROS2::HumanWorker
                 editContext
                     ->Class<AnimGraphInputProviderComponent>("AnimGraph Input Provider", "Component that feeds the anim graph input.")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->Attribute(AZ::Edit::Attributes::Category, "HumanWorker")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AnimGraphInputProviderComponent::m_rigidBodyEntityId, "Rigid Body", "")
                     ->DataElement(
@@ -79,4 +79,4 @@ namespace ROS2::HumanWorker
             "Speed",
             linearSpeed * m_linearSpeedMultiplier);
     }
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/AnimGraphInputProviderComponent.h
+++ b/Code/Source/HumanWorker/AnimGraphInputProviderComponent.h
@@ -13,7 +13,7 @@
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Component/TickBus.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     class AnimGraphInputProviderComponent
         : public AZ::Component
@@ -47,4 +47,4 @@ namespace ROS2::HumanWorker
         AZ::EntityId m_rigidBodyEntityId;
         float m_linearSpeedMultiplier{ 0.05f };
     };
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.cpp
+++ b/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.cpp
@@ -12,7 +12,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <RecastNavigation/RecastNavigationMeshBus.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     void NavigationMeshOrchestratorComponent::Reflect(AZ::ReflectContext* context)
     {
@@ -29,7 +29,7 @@ namespace ROS2::HumanWorker
             {
                 editContext->Class<NavigationMeshOrchestratorComponent>("Navigation Orchestrator", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->Attribute(AZ::Edit::Attributes::Category, "HumanWorker")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
@@ -112,4 +112,4 @@ namespace ROS2::HumanWorker
         RecastNavigation::RecastNavigationMeshRequestBus::EventResult(
             success, GetEntityId(), &RecastNavigation::RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
     }
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.h
+++ b/Code/Source/HumanWorker/NavigationMeshOrchestratorComponent.h
@@ -15,7 +15,7 @@
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <ROS2/Communication/TopicConfiguration.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     class NavigationMeshOrchestratorComponent
         : public AZ::Component
@@ -54,4 +54,4 @@ namespace ROS2::HumanWorker
         int m_delayedTickUpdate{ 0 };
         bool m_delayedTickUpdateActive{ false };
     };
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/NpcNavigatorComponent.cpp
+++ b/Code/Source/HumanWorker/NpcNavigatorComponent.cpp
@@ -20,16 +20,15 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <HumanWorker/WaypointBus.h>
 #include <LmbrCentral/Scripting/TagComponentBus.h>
+#include <LmbrCentral/Shape/ShapeComponentBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2GemUtilities.h>
 #include <ROS2/Utilities/ROS2Names.h>
 #include <RecastNavigation/DetourNavigationBus.h>
 #include <RecastNavigation/RecastNavigationMeshBus.h>
-#include <LmbrCentral/Shape/ShapeComponentBus.h>
-#include <LmbrCentral/Scripting/TagComponentBus.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     NpcNavigatorComponent::NpcNavigatorComponent()
     {
@@ -195,7 +194,6 @@ namespace ROS2::HumanWorker
         const AZ::Vector3 RobotPosition = currentTransform.GetTranslation();
         const AZ::Vector3 RobotDirection = currentTransform.GetBasisX().GetNormalized();
 
-
         // get deny bubble entities
         AZ::EBusAggregateResults<AZ::EntityId> aggregator;
         LmbrCentral::TagGlobalRequestBus::EventResult(aggregator, SafetyBubbleTag, &LmbrCentral::TagGlobalRequests::RequestTaggedEntities);
@@ -211,7 +209,6 @@ namespace ROS2::HumanWorker
                 return { .m_linear = 0.0f, .m_angular = 0.0f };
             }
         }
-
 
         float bearingError = 0.0f;
         if (goal.m_position != RobotPosition)
@@ -257,7 +254,7 @@ namespace ROS2::HumanWorker
     }
 
     NpcNavigatorComponent::PublisherPtr NpcNavigatorComponent::CreatePublisher(
-        ROS2FrameComponent* frame, const ROS2::TopicConfiguration& topicConfiguration)
+        ROS2::ROS2FrameComponent* frame, const ROS2::TopicConfiguration& topicConfiguration)
     {
         auto ros2Node = ROS2::ROS2Interface::Get()->GetNode();
         const auto& topicName = ROS2::ROS2Names::GetNamespacedName(frame->GetNamespace(), topicConfiguration.m_topic);
@@ -366,4 +363,4 @@ namespace ROS2::HumanWorker
     {
         return !m_useTagsForNavigationMesh;
     }
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/NpcNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcNavigatorComponent.h
@@ -25,7 +25,7 @@
 #include <geometry_msgs/msg/twist.hpp>
 #include <rclcpp/publisher.hpp>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     class NpcNavigatorComponent
         : public AZ::Component
@@ -34,7 +34,7 @@ namespace ROS2::HumanWorker
         , private RecastNavigation::RecastNavigationMeshNotificationBus::Handler
     {
     public:
-        static constexpr  AZ::Crc32 SafetyBubbleTag = AZ_CRC_CE("SafetyBubble");
+        static constexpr AZ::Crc32 SafetyBubbleTag = AZ_CRC_CE("SafetyBubble");
 
         AZ_RTTI(NpcNavigatorComponent, "{BA4E4F96-A88C-406B-853B-E05911D190C4}", AZ::Component);
 
@@ -75,7 +75,7 @@ namespace ROS2::HumanWorker
         static float GetSignedAngleBetweenUnitVectors(const AZ::Vector3& unitVector1, const AZ::Vector3& unitVector2);
         static AZ::Transform GetEntityTransform(const AZ::EntityId& entityId);
         static NpcNavigatorComponent::PublisherPtr CreatePublisher(
-            ROS2FrameComponent* frame, const ROS2::TopicConfiguration& topicConfiguration);
+            ROS2::ROS2FrameComponent* frame, const ROS2::TopicConfiguration& topicConfiguration);
         static bool IsClose(const AZ::Vector3& vector1, const AZ::Vector3& vector2, float acceptableDistanceError);
         [[nodiscard]] AZ::Transform GetCurrentTransform() const;
 
@@ -146,7 +146,7 @@ namespace ROS2::HumanWorker
         bool m_preventWalkingInCircle{ false };
 
         // ROS2 communication variables
-        TopicConfiguration m_twistTopicConfiguration;
+        ROS2::TopicConfiguration m_twistTopicConfiguration;
         PublisherPtr m_publisher;
     };
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/NpcPoseNavigatorComponent.cpp
+++ b/Code/Source/HumanWorker/NpcPoseNavigatorComponent.cpp
@@ -23,7 +23,7 @@
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <ROS2/Utilities/ROS2Names.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     NpcPoseNavigatorComponent::NpcPoseNavigatorComponent()
         : NpcNavigatorComponent()
@@ -226,4 +226,4 @@ namespace ROS2::HumanWorker
         m_goalIndex = 0;
         m_goalPath = TryFindGoalPath();
     }
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcPoseNavigatorComponent.h
@@ -23,7 +23,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     class NpcPoseNavigatorComponent : public NpcNavigatorComponent
     {
@@ -55,4 +55,4 @@ namespace ROS2::HumanWorker
         std::unique_ptr<tf2_ros::Buffer> m_tfBuffer = nullptr;
         std::unique_ptr<tf2_ros::TransformListener> m_tfListener = nullptr;
     };
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.cpp
+++ b/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.cpp
@@ -12,12 +12,8 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <HumanWorker/WaypointBus.h>
-#include <ROS2/Frame/ROS2FrameComponent.h>
-#include <ROS2/ROS2Bus.h>
-#include <ROS2/ROS2GemUtilities.h>
-#include <ROS2/Utilities/ROS2Names.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     void NpcWaypointNavigatorComponent::Reflect(AZ::ReflectContext* context)
     {
@@ -204,4 +200,4 @@ namespace ROS2::HumanWorker
         m_waypointEntities.push_back(location);
         m_restartOnTraversed = false;
     }
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.h
+++ b/Code/Source/HumanWorker/NpcWaypointNavigatorComponent.h
@@ -17,11 +17,10 @@
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/containers/queue.h>
 #include <AzCore/std/containers/vector.h>
-#include <ROS2/Communication/TopicConfiguration.h>
 #include <geometry_msgs/msg/twist.hpp>
 #include <rclcpp/publisher.hpp>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     class NpcWaypointNavigatorComponent
         : public NpcNavigatorComponent
@@ -57,4 +56,4 @@ namespace ROS2::HumanWorker
 
         bool m_restartOnTraversed{ true };
     };
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/WaypointComponent.cpp
+++ b/Code/Source/HumanWorker/WaypointComponent.cpp
@@ -8,7 +8,7 @@
  */
 #include <HumanWorker/WaypointComponent.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     void WaypointComponent::Reflect(AZ::ReflectContext* context)
     {
@@ -24,7 +24,7 @@ namespace ROS2::HumanWorker
                 editContext
                     ->Class<WaypointComponent>("Waypoint", "Waypoint")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                        ->Attribute(AZ::Edit::Attributes::Category, "HumanWorker")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &WaypointComponent::m_configuration, "Waypoint Configuration", "Waypoint Configuration");
                 // clang-format on
@@ -46,4 +46,4 @@ namespace ROS2::HumanWorker
     {
         return m_configuration;
     }
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/WaypointComponent.h
+++ b/Code/Source/HumanWorker/WaypointComponent.h
@@ -12,7 +12,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <HumanWorker/WaypointBus.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     //! Component that signifies a waypoint.
     //! The waypoint may be configured to capture its orientation
@@ -41,4 +41,4 @@ namespace ROS2::HumanWorker
     private:
         WaypointConfiguration m_configuration;
     };
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/WaypointSelectorComponent.cpp
+++ b/Code/Source/HumanWorker/WaypointSelectorComponent.cpp
@@ -9,7 +9,7 @@
 #include <HumanWorker/NpcNavigatorBus.h>
 #include <HumanWorker/WaypointSelectorComponent.h>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     void WaypointSelectorComponent::Reflect(AZ::ReflectContext* context)
     {
@@ -82,4 +82,4 @@ namespace ROS2::HumanWorker
 
         return waypointPath;
     }
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorker/WaypointSelectorComponent.h
+++ b/Code/Source/HumanWorker/WaypointSelectorComponent.h
@@ -15,7 +15,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <random>
 
-namespace ROS2::HumanWorker
+namespace HumanWorker
 {
     //! Component used to construct a randomized path
     //! from a provided waypoint set for selected Npc Navigators.
@@ -48,4 +48,4 @@ namespace ROS2::HumanWorker
         std::mt19937 m_mersenneTwister{ m_seed };
         AZStd::vector<AZ::EntityId> m_humanNpcs, m_waypoints;
     };
-} // namespace ROS2::HumanWorker
+} // namespace HumanWorker

--- a/Code/Source/HumanWorkerModuleInterface.cpp
+++ b/Code/Source/HumanWorkerModuleInterface.cpp
@@ -28,12 +28,12 @@ namespace HumanWorker
         m_descriptors.insert(
             m_descriptors.end(),
             {
-                ROS2::HumanWorker::AnimGraphInputProviderComponent::CreateDescriptor(),
-                ROS2::HumanWorker::NavigationMeshOrchestratorComponent::CreateDescriptor(),
-                ROS2::HumanWorker::WaypointComponent::CreateDescriptor(),
-                ROS2::HumanWorker::WaypointSelectorComponent::CreateDescriptor(),
-                ROS2::HumanWorker::NpcWaypointNavigatorComponent::CreateDescriptor(),
-                ROS2::HumanWorker::NpcPoseNavigatorComponent::CreateDescriptor(),
+                HumanWorker::AnimGraphInputProviderComponent::CreateDescriptor(),
+                HumanWorker::NavigationMeshOrchestratorComponent::CreateDescriptor(),
+                HumanWorker::WaypointComponent::CreateDescriptor(),
+                HumanWorker::WaypointSelectorComponent::CreateDescriptor(),
+                HumanWorker::NpcWaypointNavigatorComponent::CreateDescriptor(),
+                HumanWorker::NpcPoseNavigatorComponent::CreateDescriptor(),
             });
     }
 } // namespace HumanWorker


### PR DESCRIPTION
Changed the namespace from `ROS2::HumanWorker` to `HumanWorker` and changed the category of the component from `ROS2` to `HumanWorker` as the codebase has not much to do with ROS2.