### PR TITLE
Added human worker to collision group that should collide only with Ground layer

### DIFF
--- a/Assets/HumanWorker/HumanWorkerRobot.prefab
+++ b/Assets/HumanWorker/HumanWorkerRobot.prefab
@@ -176,6 +176,12 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 1657780093315026513,
                     "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 3
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{72AB7AF0-F57A-4DA8-8498-3DBCF3789BAE}"
+                        },
                         "Position": [
                             0.0,
                             0.0,


### PR DESCRIPTION
There is absolutely no need for NPCs to collide with anything. Currently those are simulated rigid bodies with robots attached. Those easily collide with ego causing mayhem in Roscondemo 2023.