### PR TITLE
Fix waypoints in prefabs

### DIFF
--- a/Assets/HumanWorker/HumanWorkerRobot.prefab
+++ b/Assets/HumanWorker/HumanWorkerRobot.prefab
@@ -217,8 +217,6 @@
                         "Angular Speed": 1.5,
                         "Cross Track Factor": 0.20000000298023224,
                         "Waypoints": [
-                            "",
-                            ""
                         ]
                     }
                 },

--- a/Assets/HumanWorker/NavigationExample.prefab
+++ b/Assets/HumanWorker/NavigationExample.prefab
@@ -525,12 +525,12 @@
                     "value": "../Entity_[9879863788140]"
                 },
                 {
-                    "op": "replace",
+                    "op": "add",
                     "path": "/Entities/Entity_[66011467218485]/Components/NpcWaypointNavigatorComponent/m_template/Waypoints/0",
                     "value": "../Entity_[9871273853548]"
                 },
                 {
-                    "op": "replace",
+                    "op": "add",
                     "path": "/Entities/Entity_[66011467218485]/Components/NpcWaypointNavigatorComponent/m_template/Waypoints/1",
                     "value": "../Entity_[9862683918956]"
                 }


### PR DESCRIPTION
I've fixed broken waypoints in human worker prefabs. These waypoints caused the human to walk to 0,0,0 two times by default. Now the prefabs work as expected.